### PR TITLE
Change to working directory before running composer

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -43,6 +43,9 @@ if (!file_exists($rootDir.'/composer.phar')) {
 // php on windows can't use the shebang line from system()
 $interpreter = defined('PHP_WINDOWS_VERSION_BUILD') ? 'php.exe' : 'php';
 
+// Change directory, as composer.phar must be run from the working directory
+chdir($rootDir);
+
 // Install/update dependencies
 system(sprintf('%s %s %s', $interpreter, escapeshellarg($rootDir.'/composer.phar'), $command));
 


### PR DESCRIPTION
For deployment purposes (e.g. DeployHQ SSH commands), it might be useful to be able to run `php bin/vendors` from outside the project's working directory. However, `php composer.phar update` will only look for a `composer.json` file in the current directory. So to be able to execute the vendors script from outside the project directory, we need to change to that directory first.
