### PR TITLE
composer.lock should be in repository if the repository is an application and not a bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ web/bundles/*
 web/uploads/*
 vendor
 composer.phar
-composer.lock


### PR DESCRIPTION
see:

http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
